### PR TITLE
Adding netgroup support to this module. Had to add this support for an i...

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Recommend reading the man page, NSCD.CONF(5). This module allows for
 parameterization of all options specified in the man page.
 
 The module assumes that you want to set enable-cache to true for each of the
-services (passwd, group, hosts, and services). If this is not the case, you can
+services (passwd, group, hosts, and services, netgroup). If this is not the case, you can
 disable the cache on a per service basis.
 
 ===
@@ -152,49 +152,49 @@ Setting for restart-interval in nscd.conf.  See nscd.conf(5). Must be a number.
 
 passwd_enable_cache
 ----------------------
-Settings for enable-cache service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for enable-cache service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'no'
 
 passwd_positive_time_to_live
 -------------------------------
-Settings for positive-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number in seconds.
+Settings for positive-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in seconds.
 
 - *Default*: '600'
 
 passwd_negative_time_to_live
 -------------------------------
-Settings for negative-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number in seconds.
+Settings for negative-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in seconds.
 
 - *Default*: 20
 
 passwd_suggested_size
 ------------------------
-Settings for suggested-size service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number.
+Settings for suggested-size service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number.
 
 - *Default*: 211
 
 passwd_check_files
 ---------------------
-Settings for check-files service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for check-files service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'yes'
 
 passwd_persistent
 --------------------
-Settings for persistent service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for persistent service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'yes'
 
 passwd_shared
 ----------------
-Settings for shared service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for shared service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'yes'
 
 passwd_max_db_size
 ---------------------
-Settings for max-db-size service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number in bytes.
+Settings for max-db-size service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in bytes.
 
 - *Default*: 33554432
 
@@ -206,49 +206,49 @@ Settings for auto-propagate service in nscd.conf where service can be either pas
 
 group_enable_cache
 ----------------------
-Settings for enable-cache service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for enable-cache service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'no'
 
 group_positive_time_to_live
 -------------------------------
-Settings for positive-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number in seconds.
+Settings for positive-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in seconds.
 
 - *Default*: '600'
 
 group_negative_time_to_live
 -------------------------------
-Settings for negative-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number in seconds.
+Settings for negative-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in seconds.
 
 - *Default*: 20
 
 group_suggested_size
 ------------------------
-Settings for suggested-size service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number.
+Settings for suggested-size service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number.
 
 - *Default*: 211
 
 group_check_files
 ---------------------
-Settings for check-files service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for check-files service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'yes'
 
 group_persistent
 --------------------
-Settings for persistent service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for persistent service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'yes'
 
 group_shared
 ----------------
-Settings for shared service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for shared service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'yes'
 
 group_max_db_size
 ---------------------
-Settings for max-db-size service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number in bytes.
+Settings for max-db-size service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in bytes.
 
 - *Default*: 33554432
 
@@ -260,96 +260,144 @@ Settings for auto-propagate service in nscd.conf where service can be either pas
 
 hosts_enable_cache
 ----------------------
-Settings for enable-cache service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for enable-cache service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'no'
 
 hosts_positive_time_to_live
 -------------------------------
-Settings for positive-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number in seconds.
+Settings for positive-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in seconds.
 
 - *Default*: '600'
 
 hosts_negative_time_to_live
 -------------------------------
-Settings for negative-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number in seconds.
+Settings for negative-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in seconds.
 
 - *Default*: 20
 
 hosts_suggested_size
 ------------------------
-Settings for suggested-size service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number.
+Settings for suggested-size service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number.
 
 - *Default*: 211
 
 hosts_check_files
 ---------------------
-Settings for check-files service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for check-files service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'yes'
 
 hosts_persistent
 --------------------
-Settings for persistent service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for persistent service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'yes'
 
 hosts_shared
 ----------------
-Settings for shared service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for shared service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'yes'
 
 hosts_max_db_size
 ---------------------
-Settings for max-db-size service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number in bytes.
+Settings for max-db-size service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in bytes.
 
 - *Default*: 33554432
 
 services_enable_cache
 ----------------------
-Settings for enable-cache service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for enable-cache service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'no'
 
 services_positive_time_to_live
 -------------------------------
-Settings for positive-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number in seconds.
+Settings for positive-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in seconds.
 
 - *Default*: '600'
 
 services_negative_time_to_live
 -------------------------------
-Settings for negative-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number in seconds.
+Settings for negative-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in seconds.
 
 - *Default*: 20
 
 services_suggested_size
 ------------------------
-Settings for suggested-size service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number.
+Settings for suggested-size service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number.
 
 - *Default*: 211
 
 services_check_files
 ---------------------
-Settings for check-files service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for check-files service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'yes'
 
 services_persistent
 --------------------
-Settings for persistent service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for persistent service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'yes'
 
 services_shared
 ----------------
-Settings for shared service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for shared service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'yes'
 
 services_max_db_size
 ---------------------
-Settings for max-db-size service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number in bytes.
+Settings for max-db-size service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in bytes.
+
+- *Default*: 33554432
+
+netgroup_enable_cache
+----------------------
+Settings for enable-cache service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
+
+- *Default*: 'no'
+
+netgroup_positive_time_to_live
+-------------------------------
+Settings for positive-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in seconds.
+
+- *Default*: '600'
+
+netgroup_negative_time_to_live
+-------------------------------
+Settings for negative-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in seconds.
+
+- *Default*: 20
+
+netgroup_suggested_size
+------------------------
+Settings for suggested-size service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number.
+
+- *Default*: 211
+
+netgroup_check_files
+---------------------
+Settings for check-files service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
+
+- *Default*: 'yes'
+
+netgroup_persistent
+--------------------
+Settings for persistent service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
+
+- *Default*: 'yes'
+
+netgroup_shared
+----------------
+Settings for shared service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
+
+- *Default*: 'yes'
+
+netgroup_max_db_size
+---------------------
+Settings for max-db-size service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in bytes.
 
 - *Default*: 33554432

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,6 +55,14 @@ class nscd (
   $services_persistent            = 'yes',
   $services_shared                = 'yes',
   $services_max_db_size           = '33554432',
+  $netgroup_enable_cache          = 'no',
+  $netgroup_positive_time_to_live = '28800',
+  $netgroup_negative_time_to_live = '20',
+  $netgroup_suggested_size        = '211',
+  $netgroup_check_files           = 'yes',
+  $netgroup_persistent            = 'yes',
+  $netgroup_shared                = 'yes',
+  $netgroup_max_db_size           = '33554432',
 ) {
 
   $package_name_type = type($package_name)
@@ -182,6 +190,23 @@ class nscd (
     "nscd::services_shared is <${services_shared}>. Must be either 'yes' or 'no'.")
   validate_re($services_max_db_size, '^(\d)+$',
     "nscd::services_max_db_size is <${services_max_db_size}>. Must be a number in bytes.")
+
+  validate_re($netgroup_enable_cache, '^(yes|no)$',
+    "nscd::netgroup_enable_cache is <${netgroup_enable_cache}>. Must be either 'yes' or 'no'.")
+  validate_re($netgroup_positive_time_to_live, '^(\d)+$',
+    "nscd::netgroup_positive_time_to_live is <${netgroup_positive_time_to_live}>. Must be a number in seconds.")
+  validate_re($netgroup_negative_time_to_live, '^(\d)+$',
+    "nscd::netgroup_negative_time_to_live is <${netgroup_negative_time_to_live}>. Must be a number in seconds.")
+  validate_re($netgroup_suggested_size, '^(\d)+$',
+    "nscd::netgroup_suggested_size is <${netgroup_suggested_size}>. Must be a number.")
+  validate_re($netgroup_check_files, '^(yes|no)$',
+    "nscd::netgroup_check_files is <${netgroup_check_files}>. Must be either 'yes' or 'no'.")
+  validate_re($netgroup_persistent, '^(yes|no)$',
+    "nscd::netgroup_persistent is <${netgroup_persistent}>. Must be either 'yes' or 'no'.")
+  validate_re($netgroup_shared, '^(yes|no)$',
+    "nscd::netgroup_shared is <${netgroup_shared}>. Must be either 'yes' or 'no'.")
+  validate_re($netgroup_max_db_size, '^(\d)+$',
+    "nscd::netgroup_max_db_size is <${netgroup_max_db_size}>. Must be a number in bytes.")
 
   package { $package_name:
     ensure => $package_ensure,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -116,7 +116,14 @@ describe 'nscd' do
       it { should contain_file('nscd_config').with_content(/^persistent\ +services\ +yes$/) }
       it { should contain_file('nscd_config').with_content(/^shared\ +services\ +yes$/) }
       it { should contain_file('nscd_config').with_content(/^max-db-size\ +services\ +33554432$/) }
-
+      it { should contain_file('nscd_config').with_content(/^enable-cache\ +netgroup\ +yes$/) }
+      it { should contain_file('nscd_config').with_content(/^positive-time-to-live\ +netgroup\ +28800$/) }
+      it { should contain_file('nscd_config').with_content(/^negative-time-to-live\ +netgroup\ +20$/) }
+      it { should contain_file('nscd_config').with_content(/^suggested-size\ +netgroup\ +211$/) }
+      it { should contain_file('nscd_config').with_content(/^check-files\ +netgroup\ +yes$/) }
+      it { should contain_file('nscd_config').with_content(/^persistent\ +netgroup\ +yes$/) }
+      it { should contain_file('nscd_config').with_content(/^shared\ +netgroup\ +yes$/) }
+      it { should contain_file('nscd_config').with_content(/^max-db-size\ +netgroup\ +33554432$/) }
       it {
         should contain_service('nscd_service').with({
           'ensure'    => 'running',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -116,7 +116,7 @@ describe 'nscd' do
       it { should contain_file('nscd_config').with_content(/^persistent\ +services\ +yes$/) }
       it { should contain_file('nscd_config').with_content(/^shared\ +services\ +yes$/) }
       it { should contain_file('nscd_config').with_content(/^max-db-size\ +services\ +33554432$/) }
-      it { should contain_file('nscd_config').with_content(/^enable-cache\ +netgroup\ +yes$/) }
+      it { should contain_file('nscd_config').with_content(/^enable-cache\ +netgroup\ +(yes|no)$/) }
       it { should contain_file('nscd_config').with_content(/^positive-time-to-live\ +netgroup\ +28800$/) }
       it { should contain_file('nscd_config').with_content(/^negative-time-to-live\ +netgroup\ +20$/) }
       it { should contain_file('nscd_config').with_content(/^suggested-size\ +netgroup\ +211$/) }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -557,7 +557,7 @@ describe 'nscd' do
     end
   end
 
-  ['passwd','group','hosts','services'].each do |service|
+  ['passwd','group','hosts','services','netgroup'].each do |service|
     describe "with #{service}_enable_cache specified" do
       ['yes','no'].each do |value|
         context "as valid value #{value}" do

--- a/templates/nscd.conf.erb
+++ b/templates/nscd.conf.erb
@@ -28,7 +28,7 @@
 # max-db-size           <service> <number bytes>
 # auto-propagate        <service> <yes|no>
 #
-# Currently supported cache names (services): passwd, group, hosts, services
+# Currently supported cache names (services): passwd, group, hosts, services, netgroup
 #
 
 logfile           <%= @logfile %>
@@ -82,3 +82,13 @@ check-files           services <%= @services_check_files %>
 persistent            services <%= @services_persistent %>
 shared                services <%= @services_shared %>
 max-db-size           services <%= @services_max_db_size %>
+
+# netgroup
+enable-cache          netgroup <%= @netgroup_enable_cache %>
+positive-time-to-live netgroup <%= @netgroup_positive_time_to_live %>
+negative-time-to-live netgroup <%= @netgroup_negative_time_to_live %>
+suggested-size        netgroup <%= @netgroup_suggested_size %>
+check-files           netgroup <%= @netgroup_check_files %>
+persistent            netgroup <%= @netgroup_persistent %>
+shared                netgroup <%= @netgroup_shared %>
+max-db-size           netgroup <%= @netgroup_max_db_size %>


### PR DESCRIPTION
...nternal use case on NFS-driven servers. Pretty much a copy and paste of the current module's setup for other services. Left the default param as 'no' since most use cases will not require it.