### PR TITLE
Allow for the config template to be overriden

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,3 +5,4 @@ fixtures:
       ref: '3.2.0'
   symlinks:
     nscd: "#{source_dir}"
+    external: "#{source_dir}/spec/external-resources/external"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,7 @@ class nscd (
   $config_owner                   = 'root',
   $config_group                   = 'root',
   $config_mode                    = '0644',
+  $config_template                = 'nscd/nscd.conf.erb',
   $service_name                   = 'nscd',
   $service_ensure                 = 'running',
   $service_enable                 = true,
@@ -69,6 +70,7 @@ class nscd (
   validate_string($config_group)
   validate_re($config_mode, '^(\d){4}$',
     "nscd::config_mode is <${config_mode}>. Must be in four digit octal notation.")
+  validate_string($config_template)
   validate_string($service_name)
   validate_re($service_ensure, '^(present)|(running)|(absent)|(stopped)$',
     'nscd::service_ensure is invalid and does not match the regex.')
@@ -190,7 +192,7 @@ class nscd (
   file { 'nscd_config':
     ensure  => file,
     path    => $config_path,
-    content => template('nscd/nscd.conf.erb'),
+    content => template($config_template),
     owner   => $config_owner,
     group   => $config_group,
     mode    => $config_mode,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -128,6 +128,29 @@ describe 'nscd' do
     end
   end
 
+  describe 'with config_template parameter specified' do
+    context 'as a valid path' do
+      let(:params) { { :config_template => 'external/nscd.conf.erb' } }
+      it { should contain_file('nscd_config').with_content(/External NSCD conf template/) }
+    end
+    context 'as an invalid path' do
+      let(:params) { { :config_template => 'fake/nscd.conf.erb' } }
+      it 'should fail' do
+        expect {
+          should contain_class('nscd')
+        }.to raise_error(Puppet::Error, /Could not find template/)
+      end
+    end
+    context 'as an invalid type' do
+      let(:params) { { :config_template => ['one','two'] } }
+      it 'should fail' do
+        expect {
+          should contain_class('nscd')
+        }.to raise_error(Puppet::Error, /is not a string.  It looks to be a Array/)
+      end
+    end
+  end
+
   describe 'with package_name parameter specified' do
     context 'as a string' do
       let(:params) { { :package_name => 'mynscd' } }

--- a/spec/external-resources/external/templates/nscd.conf.erb
+++ b/spec/external-resources/external/templates/nscd.conf.erb
@@ -1,0 +1,1 @@
+# External NSCD conf template


### PR DESCRIPTION
I find it useful to be able to override template in use (makes it possible for users to work around problems like the RHEL5 services issue without needing to wait for code changes).