### PR TITLE
Add enable flags for each db (passwd,group,host,services,netgroup)

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,3 +5,4 @@ fixtures:
       ref: '3.2.0'
   symlinks:
     nscd: "#{source_dir}"
+    external: "#{source_dir}/spec/external-resources/external"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Recommend reading the man page, NSCD.CONF(5). This module allows for
 parameterization of all options specified in the man page.
 
 The module assumes that you want to set enable-cache to true for each of the
-services (passwd, group, hosts, and services). If this is not the case, you can
+services (passwd, group, hosts, and services, netgroup). If this is not the case, you can
 disable the cache on a per service basis.
 
 ===
@@ -69,6 +69,12 @@ config_mode
 Mode of nscd.conf. Must be in four digit octal notation.
 
 - *Default*: '0644'
+
+config_template
+-----------
+Path to the template to for nscd.conf. Must be a string.
+
+- *Default*: 'nscd/nscd.conf.erb'
 
 service_name
 ------------
@@ -150,51 +156,81 @@ Setting for restart-interval in nscd.conf.  See nscd.conf(5). Must be a number.
 ## Per service nscd.conf settings
 ---
 
+enable_db_passwd
+------------------
+Determines whether to include the configuration stanza for the passwd service. Must be a boolean.
+
+- *Default*: OS specific
+
+enable_db_group
+------------------
+Determines whether to include the configuration stanza for the group service. Must be a boolean.
+
+- *Default*: OS specific
+
+enable_db_hosts
+------------------
+Determines whether to include the configuration stanza for the hosts service. Must be a boolean.
+
+- *Default*: OS specific
+
+enable_db_services
+------------------
+Determines whether to include the configuration stanza for the services service. Must be a boolean.
+
+- *Default*: OS specific
+
+enable_db_netgroup
+------------------
+Determines whether to include the configuration stanza for the netgroup service. Must be a boolean.
+
+- *Default*: OS specific
+
 passwd_enable_cache
 ----------------------
-Settings for enable-cache service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for enable-cache service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'no'
 
 passwd_positive_time_to_live
 -------------------------------
-Settings for positive-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number in seconds.
+Settings for positive-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in seconds.
 
 - *Default*: '600'
 
 passwd_negative_time_to_live
 -------------------------------
-Settings for negative-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number in seconds.
+Settings for negative-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in seconds.
 
 - *Default*: 20
 
 passwd_suggested_size
 ------------------------
-Settings for suggested-size service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number.
+Settings for suggested-size service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number.
 
 - *Default*: 211
 
 passwd_check_files
 ---------------------
-Settings for check-files service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for check-files service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'yes'
 
 passwd_persistent
 --------------------
-Settings for persistent service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for persistent service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'yes'
 
 passwd_shared
 ----------------
-Settings for shared service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for shared service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'yes'
 
 passwd_max_db_size
 ---------------------
-Settings for max-db-size service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number in bytes.
+Settings for max-db-size service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in bytes.
 
 - *Default*: 33554432
 
@@ -206,49 +242,49 @@ Settings for auto-propagate service in nscd.conf where service can be either pas
 
 group_enable_cache
 ----------------------
-Settings for enable-cache service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for enable-cache service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'no'
 
 group_positive_time_to_live
 -------------------------------
-Settings for positive-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number in seconds.
+Settings for positive-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in seconds.
 
 - *Default*: '600'
 
 group_negative_time_to_live
 -------------------------------
-Settings for negative-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number in seconds.
+Settings for negative-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in seconds.
 
 - *Default*: 20
 
 group_suggested_size
 ------------------------
-Settings for suggested-size service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number.
+Settings for suggested-size service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number.
 
 - *Default*: 211
 
 group_check_files
 ---------------------
-Settings for check-files service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for check-files service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'yes'
 
 group_persistent
 --------------------
-Settings for persistent service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for persistent service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'yes'
 
 group_shared
 ----------------
-Settings for shared service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for shared service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'yes'
 
 group_max_db_size
 ---------------------
-Settings for max-db-size service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number in bytes.
+Settings for max-db-size service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in bytes.
 
 - *Default*: 33554432
 
@@ -260,96 +296,144 @@ Settings for auto-propagate service in nscd.conf where service can be either pas
 
 hosts_enable_cache
 ----------------------
-Settings for enable-cache service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for enable-cache service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'no'
 
 hosts_positive_time_to_live
 -------------------------------
-Settings for positive-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number in seconds.
+Settings for positive-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in seconds.
 
 - *Default*: '600'
 
 hosts_negative_time_to_live
 -------------------------------
-Settings for negative-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number in seconds.
+Settings for negative-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in seconds.
 
 - *Default*: 20
 
 hosts_suggested_size
 ------------------------
-Settings for suggested-size service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number.
+Settings for suggested-size service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number.
 
 - *Default*: 211
 
 hosts_check_files
 ---------------------
-Settings for check-files service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for check-files service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'yes'
 
 hosts_persistent
 --------------------
-Settings for persistent service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for persistent service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'yes'
 
 hosts_shared
 ----------------
-Settings for shared service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for shared service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'yes'
 
 hosts_max_db_size
 ---------------------
-Settings for max-db-size service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number in bytes.
+Settings for max-db-size service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in bytes.
 
 - *Default*: 33554432
 
 services_enable_cache
 ----------------------
-Settings for enable-cache service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for enable-cache service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'no'
 
 services_positive_time_to_live
 -------------------------------
-Settings for positive-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number in seconds.
+Settings for positive-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in seconds.
 
 - *Default*: '600'
 
 services_negative_time_to_live
 -------------------------------
-Settings for negative-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number in seconds.
+Settings for negative-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in seconds.
 
 - *Default*: 20
 
 services_suggested_size
 ------------------------
-Settings for suggested-size service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number.
+Settings for suggested-size service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number.
 
 - *Default*: 211
 
 services_check_files
 ---------------------
-Settings for check-files service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for check-files service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'yes'
 
 services_persistent
 --------------------
-Settings for persistent service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for persistent service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'yes'
 
 services_shared
 ----------------
-Settings for shared service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for shared service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
 
 - *Default*: 'yes'
 
 services_max_db_size
 ---------------------
-Settings for max-db-size service in nscd.conf where service can be either passwd, group, hosts, services. Must be a number in bytes.
+Settings for max-db-size service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in bytes.
+
+- *Default*: 33554432
+
+netgroup_enable_cache
+----------------------
+Settings for enable-cache service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
+
+- *Default*: 'no'
+
+netgroup_positive_time_to_live
+-------------------------------
+Settings for positive-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in seconds.
+
+- *Default*: '600'
+
+netgroup_negative_time_to_live
+-------------------------------
+Settings for negative-time-to-live service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in seconds.
+
+- *Default*: 20
+
+netgroup_suggested_size
+------------------------
+Settings for suggested-size service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number.
+
+- *Default*: 211
+
+netgroup_check_files
+---------------------
+Settings for check-files service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
+
+- *Default*: 'yes'
+
+netgroup_persistent
+--------------------
+Settings for persistent service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
+
+- *Default*: 'yes'
+
+netgroup_shared
+----------------
+Settings for shared service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be 'yes' or 'no'.
+
+- *Default*: 'yes'
+
+netgroup_max_db_size
+---------------------
+Settings for max-db-size service in nscd.conf where service can be either passwd, group, hosts, services, netgroup. Must be a number in bytes.
 
 - *Default*: 33554432

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,7 @@ class nscd (
   $enable_db_group                = 'USE_DEFAULTS',
   $enable_db_hosts                = 'USE_DEFAULTS',
   $enable_db_services             = 'USE_DEFAULTS',
+  $enable_db_netgroup             = 'USE_DEFAULTS',
   $passwd_enable_cache            = 'yes',
   $passwd_positive_time_to_live   = '600',
   $passwd_negative_time_to_live   = '20',
@@ -60,6 +61,14 @@ class nscd (
   $services_persistent            = 'yes',
   $services_shared                = 'yes',
   $services_max_db_size           = '33554432',
+  $netgroup_enable_cache          = 'no',
+  $netgroup_positive_time_to_live = '28800',
+  $netgroup_negative_time_to_live = '20',
+  $netgroup_suggested_size        = '211',
+  $netgroup_check_files           = 'yes',
+  $netgroup_persistent            = 'yes',
+  $netgroup_shared                = 'yes',
+  $netgroup_max_db_size           = '33554432',
 ) {
 
   $package_name_type = type($package_name)
@@ -101,12 +110,14 @@ class nscd (
           $enable_db_group_default     = true
           $enable_db_hosts_default     = true
           $enable_db_services_default  = false
+          $enable_db_netgroup_default  = false
         }
         default: {
           $enable_db_passwd_default    = true
           $enable_db_group_default     = true
           $enable_db_hosts_default     = true
           $enable_db_services_default  = true
+          $enable_db_netgroup_default  = false
         }
       }
     }
@@ -116,6 +127,7 @@ class nscd (
       $enable_db_group_default     = true
       $enable_db_hosts_default     = true
       $enable_db_services_default  = true
+      $enable_db_netgroup_default  = false
     }
   }
 
@@ -158,6 +170,15 @@ class nscd (
     $enable_db_services_real = $enable_db_services ? {
       'USE_DEFAULTS' => $enable_db_services_default,
       default        => str2bool($enable_db_services)
+    }
+  }
+
+  if type($enable_db_netgroup) == 'boolean' {
+    $enable_db_netgroup_real = $enable_db_netgroup
+  } else {
+    $enable_db_netgroup_real = $enable_db_netgroup ? {
+      'USE_DEFAULTS' => $enable_db_netgroup_default,
+      default        => str2bool($enable_db_netgroup)
     }
   }
 
@@ -246,6 +267,23 @@ class nscd (
   validate_bool($enable_db_group_real)
   validate_bool($enable_db_hosts_real)
   validate_bool($enable_db_services_real)
+
+  validate_re($netgroup_enable_cache, '^(yes|no)$',
+    "nscd::netgroup_enable_cache is <${netgroup_enable_cache}>. Must be either 'yes' or 'no'.")
+  validate_re($netgroup_positive_time_to_live, '^(\d)+$',
+    "nscd::netgroup_positive_time_to_live is <${netgroup_positive_time_to_live}>. Must be a number in seconds.")
+  validate_re($netgroup_negative_time_to_live, '^(\d)+$',
+    "nscd::netgroup_negative_time_to_live is <${netgroup_negative_time_to_live}>. Must be a number in seconds.")
+  validate_re($netgroup_suggested_size, '^(\d)+$',
+    "nscd::netgroup_suggested_size is <${netgroup_suggested_size}>. Must be a number.")
+  validate_re($netgroup_check_files, '^(yes|no)$',
+    "nscd::netgroup_check_files is <${netgroup_check_files}>. Must be either 'yes' or 'no'.")
+  validate_re($netgroup_persistent, '^(yes|no)$',
+    "nscd::netgroup_persistent is <${netgroup_persistent}>. Must be either 'yes' or 'no'.")
+  validate_re($netgroup_shared, '^(yes|no)$',
+    "nscd::netgroup_shared is <${netgroup_shared}>. Must be either 'yes' or 'no'.")
+  validate_re($netgroup_max_db_size, '^(\d)+$',
+    "nscd::netgroup_max_db_size is <${netgroup_max_db_size}>. Must be a number in bytes.")
 
   package { $package_name:
     ensure => $package_ensure,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,7 @@ class nscd (
   $config_owner                   = 'root',
   $config_group                   = 'root',
   $config_mode                    = '0644',
+  $config_template                = 'nscd/nscd.conf.erb',
   $service_name                   = 'nscd',
   $service_ensure                 = 'running',
   $service_enable                 = true,
@@ -69,6 +70,7 @@ class nscd (
   validate_string($config_group)
   validate_re($config_mode, '^(\d){4}$',
     "nscd::config_mode is <${config_mode}>. Must be in four digit octal notation.")
+  validate_string($config_template)
   validate_string($service_name)
   validate_re($service_ensure, '^(present)|(running)|(absent)|(stopped)$',
     'nscd::service_ensure is invalid and does not match the regex.')
@@ -190,7 +192,7 @@ class nscd (
   file { 'nscd_config':
     ensure  => file,
     path    => $config_path,
-    content => template('nscd/nscd.conf.erb'),
+    content => template($config_template),
     owner   => $config_owner,
     group   => $config_group,
     mode    => $config_mode,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,10 +79,11 @@ class nscd (
   validate_re($service_ensure, '^(present)|(running)|(absent)|(stopped)$',
     'nscd::service_ensure is invalid and does not match the regex.')
 
-  if type($service_enable) == 'String' {
-    $service_enable_real = str2bool($service_enable)
-  } else {
-    $service_enable_real = $service_enable
+  $service_enable_type = type($service_enable)
+  case $service_enable_type {
+    'String':  { $service_enable_real = str2bool($service_enable) }
+    'boolean': { $service_enable_real = $service_enable }
+    default: { fail("nscd::service_enable must be a string or a boolean. Detected type is <${service_enable_type}>.") }
   }
 
   validate_absolute_path($logfile)
@@ -101,12 +102,12 @@ class nscd (
           $enable_db_hosts_default     = true
           $enable_db_services_default  = false
         }
-        '6': {
+        default: {
           $enable_db_passwd_default    = true
           $enable_db_group_default     = true
           $enable_db_hosts_default     = true
           $enable_db_services_default  = true
-          }
+        }
       }
     }
     default: {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -108,14 +108,27 @@ describe 'nscd' do
       it { should contain_file('nscd_config').with_content(/^persistent\ +hosts\ +yes$/) }
       it { should contain_file('nscd_config').with_content(/^shared\ +hosts\ +yes$/) }
       it { should contain_file('nscd_config').with_content(/^max-db-size\ +hosts\ +33554432$/) }
-      it { should contain_file('nscd_config').with_content(/^enable-cache\ +services\ +yes$/) }
-      it { should contain_file('nscd_config').with_content(/^positive-time-to-live\ +services\ +28800$/) }
-      it { should contain_file('nscd_config').with_content(/^negative-time-to-live\ +services\ +20$/) }
-      it { should contain_file('nscd_config').with_content(/^suggested-size\ +services\ +211$/) }
-      it { should contain_file('nscd_config').with_content(/^check-files\ +services\ +yes$/) }
-      it { should contain_file('nscd_config').with_content(/^persistent\ +services\ +yes$/) }
-      it { should contain_file('nscd_config').with_content(/^shared\ +services\ +yes$/) }
-      it { should contain_file('nscd_config').with_content(/^max-db-size\ +services\ +33554432$/) }
+      
+      #RedHat 5 should not contain the service delcaration
+      if k.eql?('el5') 
+        it { should_not contain_file('nscd_config').with_content(/^enable-cache\ +services/) }
+        it { should_not contain_file('nscd_config').with_content(/^positive-time-to-live\ +services/) }
+        it { should_not contain_file('nscd_config').with_content(/^negative-time-to-live\ +services/) }
+        it { should_not contain_file('nscd_config').with_content(/^suggested-size\ +services/) }
+        it { should_not contain_file('nscd_config').with_content(/^check-files\ +services/) }
+        it { should_not contain_file('nscd_config').with_content(/^persistent\ +services/) }
+        it { should_not contain_file('nscd_config').with_content(/^shared\ +services/) }
+        it { should_not contain_file('nscd_config').with_content(/^max-db-size\ +services/) }
+      else
+        it { should contain_file('nscd_config').with_content(/^enable-cache\ +services\ +yes$/) }
+        it { should contain_file('nscd_config').with_content(/^positive-time-to-live\ +services\ +28800$/) }
+        it { should contain_file('nscd_config').with_content(/^negative-time-to-live\ +services\ +20$/) }
+        it { should contain_file('nscd_config').with_content(/^suggested-size\ +services\ +211$/) }
+        it { should contain_file('nscd_config').with_content(/^check-files\ +services\ +yes$/) }
+        it { should contain_file('nscd_config').with_content(/^persistent\ +services\ +yes$/) }
+        it { should contain_file('nscd_config').with_content(/^shared\ +services\ +yes$/) }
+        it { should contain_file('nscd_config').with_content(/^max-db-size\ +services\ +33554432$/) }
+      end
 
       it {
         should contain_service('nscd_service').with({

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -130,6 +130,16 @@ describe 'nscd' do
         it { should contain_file('nscd_config').with_content(/^max-db-size\ +services\ +33554432$/) }
       end
 
+      #By default everywhere would have enable_db_netgroup = false, so make sure the netgroup stuff is absent
+      it { should_not contain_file('nscd_config').with_content(/^enable-cache\ +netgroup/) }
+      it { should_not contain_file('nscd_config').with_content(/^positive-time-to-live\ +netgroup/) }
+      it { should_not contain_file('nscd_config').with_content(/^negative-time-to-live\ +netgroup/) }
+      it { should_not contain_file('nscd_config').with_content(/^suggested-size\ +netgroup/) }
+      it { should_not contain_file('nscd_config').with_content(/^check-files\ +netgroup/) }
+      it { should_not contain_file('nscd_config').with_content(/^persistent\ +netgroup/) }
+      it { should_not contain_file('nscd_config').with_content(/^shared\ +netgroup/) }
+      it { should_not contain_file('nscd_config').with_content(/^max-db-size\ +netgroup/) }
+
       it {
         should contain_service('nscd_service').with({
           'ensure'    => 'running',
@@ -593,11 +603,11 @@ describe 'nscd' do
     end
   end
 
-  ['passwd','group','hosts','services'].each do |service|
+  ['passwd','group','hosts','services','netgroup'].each do |service|
     describe "with #{service}_enable_cache specified" do
       ['yes','no'].each do |value|
         context "as valid value #{value}" do
-          let(:params) { { :"#{service}_enable_cache" => value } }
+          let(:params) { {:"enable_db_#{service}" => true, :"#{service}_enable_cache" => value } }
 
           it { should contain_file('nscd_config').with_content(/^enable-cache\ +#{service}\ +#{value}$/) }
         end
@@ -605,7 +615,7 @@ describe 'nscd' do
 
       ['yess','nooo','-1',true].each do |value|
         context "as invalid value #{value}" do
-          let(:params) { { :"#{service}_enable_cache" => value } }
+          let(:params) { { :"enable_db_#{service}" => true, :"#{service}_enable_cache" => value } }
 
           it 'should fail' do
             expect {
@@ -618,13 +628,13 @@ describe 'nscd' do
 
     describe "with #{service}_positive_time_to_live specified" do
       context 'as a valid number' do
-        let(:params) { { :"#{service}_positive_time_to_live" => '31415' } }
+        let(:params) { { :"enable_db_#{service}" => true, :"#{service}_positive_time_to_live" => '31415' } }
 
         it { should contain_file('nscd_config').with_content(/^positive-time-to-live\ +#{service}\ +31415$/) }
       end
 
       context 'as an invalid value' do
-        let(:params) { { :"#{service}_positive_time_to_live" => 'x' } }
+        let(:params) { { :"enable_db_#{service}" => true, :"#{service}_positive_time_to_live" => 'x' } }
 
         it 'should fail' do
           expect {
@@ -634,7 +644,7 @@ describe 'nscd' do
       end
 
       context 'as an invalid type' do
-        let(:params) { { :"#{service}_positive_time_to_live" => true } }
+        let(:params) { { :"enable_db_#{service}" => true, :"#{service}_positive_time_to_live" => true } }
 
         it 'should fail' do
           expect {
@@ -646,13 +656,13 @@ describe 'nscd' do
 
     describe "with #{service}_negative_time_to_live specified" do
       context 'as a valid number' do
-        let(:params) { { :"#{service}_negative_time_to_live" => '23' } }
+        let(:params) { { :"enable_db_#{service}" => true, :"#{service}_negative_time_to_live" => '23' } }
 
         it { should contain_file('nscd_config').with_content(/^negative-time-to-live\ +#{service}\ +23$/) }
       end
 
       context 'as an invalid value' do
-        let(:params) { { :"#{service}_negative_time_to_live" => 'x' } }
+        let(:params) { { :"enable_db_#{service}" => true, :"#{service}_negative_time_to_live" => 'x' } }
 
         it 'should fail' do
           expect {
@@ -662,7 +672,7 @@ describe 'nscd' do
       end
 
       context 'as an invalid type' do
-        let(:params) { { :"#{service}_negative_time_to_live" => true } }
+        let(:params) { { :"enable_db_#{service}" => true, :"#{service}_negative_time_to_live" => true } }
 
         it 'should fail' do
           expect {
@@ -674,13 +684,13 @@ describe 'nscd' do
 
     describe "with #{service}_suggested_size specified" do
       context 'as a valid number' do
-        let(:params) { { :"#{service}_suggested_size" => '411' } }
+        let(:params) { { :"enable_db_#{service}" => true, :"#{service}_suggested_size" => '411' } }
 
         it { should contain_file('nscd_config').with_content(/^suggested-size\ +#{service}\ +411$/) }
       end
 
       context 'as an invalid value' do
-        let(:params) { { :"#{service}_suggested_size" => 'x' } }
+        let(:params) { { :"enable_db_#{service}" => true, :"#{service}_suggested_size" => 'x' } }
 
         it 'should fail' do
           expect {
@@ -690,7 +700,7 @@ describe 'nscd' do
       end
 
       context 'as an invalid type' do
-        let(:params) { { :"#{service}_suggested_size" => true } }
+        let(:params) { { :"enable_db_#{service}" => true, :"#{service}_suggested_size" => true } }
 
         it 'should fail' do
           expect {
@@ -703,7 +713,7 @@ describe 'nscd' do
     describe "with #{service}_check_files specified" do
       ['yes','no'].each do |value|
         context "as valid value #{value}" do
-          let(:params) { { :"#{service}_check_files" => value } }
+          let(:params) { { :"enable_db_#{service}" => true, :"#{service}_check_files" => value } }
 
           it { should contain_file('nscd_config').with_content(/^check-files\ +#{service}\ +#{value}$/) }
         end
@@ -711,7 +721,7 @@ describe 'nscd' do
 
       ['yess','nooo','-1',true].each do |value|
         context "as invalid value #{value}" do
-          let(:params) { { :"#{service}_check_files" => value } }
+          let(:params) { { :"enable_db_#{service}" => true, :"#{service}_check_files" => value } }
 
           it 'should fail' do
             expect {
@@ -725,7 +735,7 @@ describe 'nscd' do
     describe "with #{service}_persistent specified" do
       ['yes','no'].each do |value|
         context "as valid value #{value}" do
-          let(:params) { { :"#{service}_persistent" => value } }
+          let(:params) { { :"enable_db_#{service}" => true, :"#{service}_persistent" => value } }
 
           it { should contain_file('nscd_config').with_content(/^persistent\ +#{service}\ +#{value}$/) }
         end
@@ -733,7 +743,7 @@ describe 'nscd' do
 
       ['yess','nooo','-1',true].each do |value|
         context "as invalid value #{value}" do
-          let(:params) { { :"#{service}_persistent" => value } }
+          let(:params) { { :"enable_db_#{service}" => true, :"#{service}_persistent" => value } }
 
           it 'should fail' do
             expect {
@@ -747,7 +757,7 @@ describe 'nscd' do
     describe "with #{service}_shared specified" do
       ['yes','no'].each do |value|
         context "as valid value #{value}" do
-          let(:params) { { :"#{service}_shared" => value } }
+          let(:params) { { :"enable_db_#{service}" => true, :"#{service}_shared" => value } }
 
           it { should contain_file('nscd_config').with_content(/^shared\ +#{service}\ +#{value}$/) }
         end
@@ -755,7 +765,7 @@ describe 'nscd' do
 
       ['yess','nooo','-1',true].each do |value|
         context "as invalid value #{value}" do
-          let(:params) { { :"#{service}_shared" => value } }
+          let(:params) { { :"enable_db_#{service}" => true, :"#{service}_shared" => value } }
 
           it 'should fail' do
             expect {
@@ -768,13 +778,13 @@ describe 'nscd' do
 
     describe "with #{service}_max_db_size specified" do
       context 'as a valid number' do
-        let(:params) { { :"#{service}_max_db_size" => '1000000' } }
+        let(:params) { { :"enable_db_#{service}" => true, :"#{service}_max_db_size" => '1000000' } }
 
         it { should contain_file('nscd_config').with_content(/^max-db-size\ +#{service}\ +1000000$/) }
       end
 
       context 'as an invalid value' do
-        let(:params) { { :"#{service}_max_db_size" => 'x' } }
+        let(:params) { { :"enable_db_#{service}" => true, :"#{service}_max_db_size" => 'x' } }
 
         it 'should fail' do
           expect {
@@ -784,7 +794,7 @@ describe 'nscd' do
       end
 
       context 'as an invalid type' do
-        let(:params) { { :"#{service}_max_db_size" => true } }
+        let(:params) { { :"enable_db_#{service}" => true, :"#{service}_max_db_size" => true } }
 
         it 'should fail' do
           expect {
@@ -799,7 +809,7 @@ describe 'nscd' do
       describe "with #{service}_auto_propagate specified" do
         ['yes','no'].each do |value|
           context "as valid value #{value}" do
-            let(:params) { { :"#{service}_auto_propagate" => value } }
+            let(:params) { { :"enable_db_#{service}" => true, :"#{service}_auto_propagate" => value } }
 
             it { should contain_file('nscd_config').with_content(/^auto-propagate\ +#{service}\ +#{value}$/) }
           end
@@ -807,7 +817,7 @@ describe 'nscd' do
 
         ['yess','nooo','-1',true].each do |value|
           context "as invalid value #{value}" do
-            let(:params) { { :"#{service}_auto_propagate" => value } }
+            let(:params) { { :"enable_db_#{service}" => true, :"#{service}_auto_propagate" => value } }
 
             it 'should fail' do
               expect {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -128,6 +128,29 @@ describe 'nscd' do
     end
   end
 
+  describe 'with config_template parameter specified' do
+    context 'as a valid path' do
+      let(:params) { { :config_template => 'external/nscd.conf.erb' } }
+      it { should contain_file('nscd_config').with_content(/External NSCD conf template/) }
+    end
+    context 'as an invalid path' do
+      let(:params) { { :config_template => 'fake/nscd.conf.erb' } }
+      it 'should fail' do
+        expect {
+          should contain_class('nscd')
+        }.to raise_error(Puppet::Error, /Could not find template/)
+      end
+    end
+    context 'as an invalid type' do
+      let(:params) { { :config_template => ['one','two'] } }
+      it 'should fail' do
+        expect {
+          should contain_class('nscd')
+        }.to raise_error(Puppet::Error, /is not a string.  It looks to be a Array/)
+      end
+    end
+  end
+
   describe 'with package_name parameter specified' do
     context 'as a string' do
       let(:params) { { :package_name => 'mynscd' } }

--- a/spec/external-resources/external/templates/nscd.conf.erb
+++ b/spec/external-resources/external/templates/nscd.conf.erb
@@ -1,0 +1,1 @@
+# External NSCD conf template

--- a/templates/nscd.conf.erb
+++ b/templates/nscd.conf.erb
@@ -28,7 +28,7 @@
 # max-db-size           <service> <number bytes>
 # auto-propagate        <service> <yes|no>
 #
-# Currently supported cache names (services): passwd, group, hosts, services
+# Currently supported cache names (services): passwd, group, hosts, services, netgroup
 #
 
 logfile           <%= @logfile %>
@@ -89,4 +89,16 @@ check-files           services <%= @services_check_files %>
 persistent            services <%= @services_persistent %>
 shared                services <%= @services_shared %>
 max-db-size           services <%= @services_max_db_size %>
+<% end -%>
+
+<% if @enable_db_netgroup_real == true -%>
+# netgroup
+enable-cache          netgroup <%= @netgroup_enable_cache %>
+positive-time-to-live netgroup <%= @netgroup_positive_time_to_live %>
+negative-time-to-live netgroup <%= @netgroup_negative_time_to_live %>
+suggested-size        netgroup <%= @netgroup_suggested_size %>
+check-files           netgroup <%= @netgroup_check_files %>
+persistent            netgroup <%= @netgroup_persistent %>
+shared                netgroup <%= @netgroup_shared %>
+max-db-size           netgroup <%= @netgroup_max_db_size %>
 <% end -%>


### PR DESCRIPTION
This really is just pulling together the work done in PR #4 and #5 (and PR #7, but less important), getting some unit testing done for #4, and setting the netgroup DB stuff adding in #5 to be off by default as having the netgroup db stanza breaks on some platforms (EL5 and EL6 with an old enough nscd, for example).