### PR TITLE
add support for VAS

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,11 +180,19 @@ Settings for enable_opt_auto_propagate in nscd.conf. Allows for boolean, 'true',
 
 - *Default*: 'USE_DEFAULTS'
 
+ensure_vas
+----------
+Should VAS (Quest Authentication Services) be used? Valid values are 'absent' and 'present'.
+Using 'present' will deactivate caching for passwd and group as recommended by Dell.
+
+- *Default*: 'absent'
+
 passwd_enable_cache
 ----------------------
-Settings for enable-cache service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for enable-cache service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes', 'no' or 'USE_DEFAULTS'.
+'USE_DEFAULTS' will activate caching if VAS is not used (see ensure_vas).
 
-- *Default*: 'no'
+- *Default*: 'USE_DEFAULTS'
 
 passwd_positive_time_to_live
 -------------------------------
@@ -236,9 +244,10 @@ Settings for auto-propagate service in nscd.conf where service can be either pas
 
 group_enable_cache
 ----------------------
-Settings for enable-cache service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes' or 'no'.
+Settings for enable-cache service in nscd.conf where service can be either passwd, group, hosts, services. Must be 'yes', 'no' or 'USE_DEFAULTS'.
+'USE_DEFAULTS' will activate caching if VAS is not used (see ensure_vas).
 
-- *Default*: 'no'
+- *Default*: 'USE_DEFAULTS'
 
 group_positive_time_to_live
 -------------------------------

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,7 +26,8 @@ class nscd (
   $enable_db_hosts                = 'USE_DEFAULTS',
   $enable_db_services             = 'USE_DEFAULTS',
   $enable_opt_auto_propagate      = 'USE_DEFAULTS',
-  $passwd_enable_cache            = 'yes',
+  $ensure_vas                     = 'absent',
+  $passwd_enable_cache            = 'USE_DEFAULTS',
   $passwd_positive_time_to_live   = '600',
   $passwd_negative_time_to_live   = '20',
   $passwd_suggested_size          = '211',
@@ -35,7 +36,7 @@ class nscd (
   $passwd_shared                  = 'yes',
   $passwd_max_db_size             = '33554432',
   $passwd_auto_propagate          = 'yes',
-  $group_enable_cache             = 'yes',
+  $group_enable_cache             = 'USE_DEFAULTS',
   $group_positive_time_to_live    = '3600',
   $group_negative_time_to_live    = '60',
   $group_suggested_size           = '211',
@@ -149,6 +150,30 @@ class nscd (
     }
   }
 
+  case $ensure_vas {
+    'absent': {
+      $passwd_enable_cache_default = 'yes'
+      $group_enable_cache_default  = 'yes'
+    }
+    'present': {
+      $passwd_enable_cache_default = 'no'
+      $group_enable_cache_default  = 'no'
+    }
+    default: {
+      fail("nscd::ensure_vas is <${ensure_vas}>. Must be either 'absent' or 'present'.")
+    }
+  }
+
+  $passwd_enable_cache_real = $passwd_enable_cache ? {
+    'USE_DEFAULTS' => $passwd_enable_cache_default,
+    default        => $passwd_enable_cache
+  }
+
+  $group_enable_cache_real = $group_enable_cache ? {
+    'USE_DEFAULTS' => $group_enable_cache_default,
+    default        => $group_enable_cache
+  }
+
   if $server_user == 'USE_DEFAULTS' {
     $server_user_real = $default_server_user
   } else {
@@ -210,8 +235,8 @@ class nscd (
   validate_re($restart_interval, '^(\d)+$',
     "nscd::restart_interval is <${restart_interval}>. Must be a number in seconds.")
 
-  validate_re($passwd_enable_cache, '^(yes|no)$',
-    "nscd::passwd_enable_cache is <${passwd_enable_cache}>. Must be either 'yes' or 'no'.")
+  validate_re($passwd_enable_cache_real, '^(yes|no)$',
+    "nscd::passwd_enable_cache is <${passwd_enable_cache}>. Must be either 'yes', 'no' or 'USE_DEFAULTS'.")
   validate_re($passwd_positive_time_to_live, '^(\d)+$',
     "nscd::passwd_positive_time_to_live is <${passwd_positive_time_to_live}>. Must be a number in seconds.")
   validate_re($passwd_negative_time_to_live, '^(\d)+$',
@@ -229,8 +254,8 @@ class nscd (
   validate_re($passwd_auto_propagate, '^(yes|no)$',
     "nscd::passwd_auto_propagate is <${passwd_auto_propagate}>. Must be either 'yes' or 'no'.")
 
-  validate_re($group_enable_cache, '^(yes|no)$',
-    "nscd::group_enable_cache is <${group_enable_cache}>. Must be either 'yes' or 'no'.")
+  validate_re($group_enable_cache_real, '^(yes|no)$',
+    "nscd::group_enable_cache is <${group_enable_cache}>. Must be either 'yes', 'no' or 'USE_DEFAULTS'.")
   validate_re($group_positive_time_to_live, '^(\d)+$',
     "nscd::group_positive_time_to_live is <${group_positive_time_to_live}>. Must be a number in seconds.")
   validate_re($group_negative_time_to_live, '^(\d)+$',

--- a/templates/nscd.conf.erb
+++ b/templates/nscd.conf.erb
@@ -43,7 +43,7 @@ restart-interval  <%= @restart_interval %>
 
 <% if @enable_db_passwd_real == true -%>
 # passwd
-enable-cache          passwd <%= @passwd_enable_cache %>
+enable-cache          passwd <%= @passwd_enable_cache_real %>
 positive-time-to-live passwd <%= @passwd_positive_time_to_live %>
 negative-time-to-live passwd <%= @passwd_negative_time_to_live %>
 suggested-size        passwd <%= @passwd_suggested_size %>
@@ -58,7 +58,7 @@ auto-propagate        passwd <%= @passwd_auto_propagate %>
 
 <% if @enable_db_group_real == true -%>
 # group
-enable-cache          group <%= @group_enable_cache %>
+enable-cache          group <%= @group_enable_cache_real %>
 positive-time-to-live group <%= @group_positive_time_to_live %>
 negative-time-to-live group <%= @group_negative_time_to_live %>
 suggested-size        group <%= @group_suggested_size %>


### PR DESCRIPTION
Dell recommends to not cache passwd and group when VAS is used.
With this patch you can use ensure_vas to switch to Dells recommended behaviour.
Setting passwd_enable_cache or group_enable_cache as specific variables will override ensure_vas settings.
