### PR TITLE
Add support for OpenSUSE 13.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This module is built for use with Puppet v3 on the following platforms and suppo
 * EL 7
 * Suse 10
 * Suse 11
+* OpenSuse 13.1
 * Ubuntu 12.04 LTS
 
 
@@ -100,6 +101,12 @@ service_enable
 Value of enable attribute of nscd service. This determines if the service will start at boot or not. Allows for boolean, 'true', or 'false'.
 
 - *Default*: true
+
+service_provider
+----------------
+String for value of the provider attribute of nscd service. Specifying here will allow you to change the platform's default.
+
+- *Default*: 'USE_DEFAULTS'
 
 ## Global nscd.conf settings
 ---

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,7 @@ class nscd (
   $service_name                   = 'nscd',
   $service_ensure                 = 'running',
   $service_enable                 = true,
+  $service_provider               = 'USE_DEFAULTS',
   $logfile                        = '/var/log/nscd.log',
   $threads                        = '5',
   $max_threads                    = '32',
@@ -104,6 +105,7 @@ class nscd (
       $default_server_user = 'nscd'
       case $::lsbmajdistrelease {
         '5': {
+          $default_service_provider          = undef
           $enable_db_passwd_default          = true
           $enable_db_group_default           = true
           $enable_db_hosts_default           = true
@@ -112,6 +114,7 @@ class nscd (
           $enable_opt_auto_propagate_default = true
         }
         '6': {
+          $default_service_provider          = undef
           $enable_db_passwd_default          = true
           $enable_db_group_default           = true
           $enable_db_hosts_default           = true
@@ -120,6 +123,7 @@ class nscd (
           $enable_opt_auto_propagate_default = true
         }
         '7': {
+          $default_service_provider          = undef
           $enable_db_passwd_default          = true
           $enable_db_group_default           = true
           $enable_db_hosts_default           = true
@@ -133,9 +137,10 @@ class nscd (
       }
     }
     'Suse': {
-      $default_server_user = undef
       case $::lsbmajdistrelease {
         '10': {
+          $default_server_user               = undef
+          $default_service_provider          = undef
           $enable_db_passwd_default          = true
           $enable_db_group_default           = true
           $enable_db_hosts_default           = true
@@ -144,11 +149,23 @@ class nscd (
           $enable_opt_auto_propagate_default = false
         }
         '11': {
+          $default_server_user               = undef
+          $default_service_provider          = undef
           $enable_db_passwd_default          = true
           $enable_db_group_default           = true
           $enable_db_hosts_default           = true
           $enable_db_services_default        = true
           $enable_db_netgroup_default        = false
+          $enable_opt_auto_propagate_default = true
+        }
+        '13': {
+          $default_server_user               = 'nscd'
+          $default_service_provider          = 'systemd'
+          $enable_db_passwd_default          = true
+          $enable_db_group_default           = true
+          $enable_db_hosts_default           = true
+          $enable_db_services_default        = true
+          $enable_db_netgroup_default        = true
           $enable_opt_auto_propagate_default = true
         }
         default: {
@@ -158,6 +175,7 @@ class nscd (
     }
     'Debian': {
       $default_server_user               = undef
+      $default_service_provider          = undef
       $enable_db_passwd_default          = true
       $enable_db_group_default           = true
       $enable_db_hosts_default           = true
@@ -174,6 +192,15 @@ class nscd (
     $server_user_real = $default_server_user
   } else {
     $server_user_real = $server_user
+  }
+
+  if $service_provider == 'USE_DEFAULTS' {
+    $service_provider_real = $default_service_provider
+  } else {
+    if $service_provider != undef {
+      validate_string($service_provider)
+    }
+    $service_provider_real = $service_provider
   }
 
   if is_bool($enable_db_passwd) {
@@ -354,6 +381,7 @@ class nscd (
     ensure    => $service_ensure,
     name      => $service_name,
     enable    => $service_enable_real,
+    provider  => $service_provider_real,
     subscribe => File['nscd_config'],
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -64,6 +64,12 @@
       "operatingsystem": "SLED"
     },
     {
+      "operatingsystem": "OpenSuSE",
+      "operatingsystemrelease": [
+        "13.1"
+      ]
+    },
+    {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "12.04"

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -7,6 +7,7 @@ describe 'nscd' do
         :lsbmajdistrelease         => '6',
         :package_name              => 'nscd',
         :server_user               => nil,
+        :service_provider          => nil,
         :enable_db_services        => true,
         :enable_db_netgroup        => false,
         :enable_opt_auto_propagate => true,
@@ -16,6 +17,7 @@ describe 'nscd' do
         :lsbmajdistrelease         => '5',
         :package_name              => 'nscd',
         :server_user               => 'nscd',
+        :service_provider          => nil,
         :enable_db_services        => false,
         :enable_db_netgroup        => false,
         :enable_opt_auto_propagate => true,
@@ -25,6 +27,7 @@ describe 'nscd' do
         :lsbmajdistrelease         => '6',
         :package_name              => 'nscd',
         :server_user               => 'nscd',
+        :service_provider          => nil,
         :enable_db_services        => true,
         :enable_db_netgroup        => false,
         :enable_opt_auto_propagate => true,
@@ -34,6 +37,7 @@ describe 'nscd' do
         :lsbmajdistrelease         => '7',
         :package_name              => 'nscd',
         :server_user               => 'nscd',
+        :service_provider          => nil,
         :enable_db_services        => true,
         :enable_db_netgroup        => true,
         :enable_opt_auto_propagate => true,
@@ -43,6 +47,7 @@ describe 'nscd' do
         :lsbmajdistrelease         => '10',
         :package_name              => 'nscd',
         :server_user               => nil,
+        :service_provider          => nil,
         :enable_db_services        => false,
         :enable_db_netgroup        => false,
         :enable_opt_auto_propagate => false,
@@ -52,8 +57,19 @@ describe 'nscd' do
         :lsbmajdistrelease         => '11',
         :package_name              => 'nscd',
         :server_user               => nil,
+        :service_provider          => nil,
         :enable_db_services        => true,
         :enable_db_netgroup        => false,
+        :enable_opt_auto_propagate => true,
+      },
+    'suse13' =>
+      { :osfamily                  => 'Suse',
+        :lsbmajdistrelease         => '13',
+        :package_name              => 'nscd',
+        :server_user               => 'nscd',
+        :service_provider          => 'systemd',
+        :enable_db_services        => true,
+        :enable_db_netgroup        => true,
         :enable_opt_auto_propagate => true,
       },
     'ubuntu12' =>
@@ -61,6 +77,7 @@ describe 'nscd' do
         :lsbmajdistrelease         => '12',
         :package_name              => 'nscd',
         :server_user               => nil,
+        :service_provider          => nil,
         :enable_db_services        => true,
         :enable_db_netgroup        => false,
         :enable_opt_auto_propagate => true,
@@ -179,14 +196,27 @@ describe 'nscd' do
         it { should contain_file('nscd_config').without_content(/^\s*max-db-size\ +netgroup/) }
       end
 
-      it {
-        should contain_service('nscd_service').with({
-          'ensure'    => 'running',
-          'name'      => 'nscd',
-          'enable'    => 'true',
-          'subscribe' => 'File[nscd_config]',
-        })
-      }
+      if v[:service_provider] != nil
+        it {
+          should contain_service('nscd_service').with({
+            'ensure'    => 'running',
+            'name'      => 'nscd',
+            'enable'    => 'true',
+            'provider'  => v[:service_provider],
+            'subscribe' => 'File[nscd_config]',
+          })
+        }
+      else
+        it {
+          should contain_service('nscd_service').with({
+            'ensure'    => 'running',
+            'name'      => 'nscd',
+            'enable'    => 'true',
+            'provider'  => nil,
+            'subscribe' => 'File[nscd_config]',
+          })
+        }
+      end
     end
   end
 
@@ -448,6 +478,26 @@ describe 'nscd' do
         expect {
           should contain_class('nscd')
         }.to raise_error(Puppet::Error)
+      end
+    end
+  end
+
+  describe 'with service_provider parameter specified' do
+    context 'as a valid string' do
+      let(:params) { { :service_provider => 'myprovider' } }
+      let(:facts) { { :osfamily => 'Debian' } }
+
+      it { should contain_service('nscd_service').with({ 'provider' => 'myprovider' }) }
+    end
+
+    context 'as an invalid type' do
+      let(:params) { { :service_provider => ['not','a','string'] } }
+      let(:facts) { { :osfamily => 'Debian' } }
+
+      it 'should fail' do
+        expect {
+          should contain_class('nscd')
+        }.to raise_error(Puppet::Error, /is not a string/)
       end
     end
   end


### PR DESCRIPTION
Had to add a service_provider parameter, since on OpenSuSE
it would try to use good old init, and fail miserably.
nscd is managed via systemd, and that must be specified.