### PR TITLE
Change fact to determine OS release from "lsbmajdistrelease" to "operatingsystemmajrelease"

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -103,7 +103,7 @@ class nscd (
   case $::osfamily {
     'RedHat': {
       $default_server_user = 'nscd'
-      case $::lsbmajdistrelease {
+      case $::operatingsystemmajrelease {
         '5': {
           $default_service_provider          = undef
           $enable_db_passwd_default          = true
@@ -132,12 +132,12 @@ class nscd (
           $enable_opt_auto_propagate_default = true
         }
         default: {
-          fail("Nscd is only supported on EL 5, 6 and 7. Your lsbmajdistrelease is identified as <${::lsbmajdistrelease}>.")
+          fail("Nscd is only supported on EL 5, 6 and 7. Your operatingsystemmajrelease is identified as <${::operatingsystemmajrelease}>.")
         }
       }
     }
     'Suse': {
-      case $::lsbmajdistrelease {
+      case $::operatingsystemmajrelease {
         '10': {
           $default_server_user               = undef
           $default_service_provider          = undef
@@ -169,7 +169,7 @@ class nscd (
           $enable_opt_auto_propagate_default = true
         }
         default: {
-          fail("Nscd is only supported on Suse 10, 11, 12 and 13. Your lsbmajdistrelease is identified as <${::lsbmajdistrelease}>.")
+          fail("Nscd is only supported on Suse 10, 11, 12 and 13. Your operatingsystemmajrelease is identified as <${::operatingsystemmajrelease}>.")
         }
       }
     }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -4,7 +4,7 @@ describe 'nscd' do
   platforms = {
     'debian6' =>
       { :osfamily                  => 'Debian',
-        :lsbmajdistrelease         => '6',
+        :operatingsystemmajrelease         => '6',
         :package_name              => 'nscd',
         :server_user               => nil,
         :service_provider          => nil,
@@ -14,7 +14,7 @@ describe 'nscd' do
       },
     'el5' =>
       { :osfamily                  => 'RedHat',
-        :lsbmajdistrelease         => '5',
+        :operatingsystemmajrelease         => '5',
         :package_name              => 'nscd',
         :server_user               => 'nscd',
         :service_provider          => nil,
@@ -24,7 +24,7 @@ describe 'nscd' do
       },
     'el6' =>
       { :osfamily                  => 'RedHat',
-        :lsbmajdistrelease         => '6',
+        :operatingsystemmajrelease         => '6',
         :package_name              => 'nscd',
         :server_user               => 'nscd',
         :service_provider          => nil,
@@ -34,7 +34,7 @@ describe 'nscd' do
       },
     'el7' =>
       { :osfamily                  => 'RedHat',
-        :lsbmajdistrelease         => '7',
+        :operatingsystemmajrelease         => '7',
         :package_name              => 'nscd',
         :server_user               => 'nscd',
         :service_provider          => nil,
@@ -44,7 +44,7 @@ describe 'nscd' do
       },
     'suse10' =>
       { :osfamily                  => 'Suse',
-        :lsbmajdistrelease         => '10',
+        :operatingsystemmajrelease         => '10',
         :package_name              => 'nscd',
         :server_user               => nil,
         :service_provider          => nil,
@@ -54,7 +54,7 @@ describe 'nscd' do
       },
     'suse11' =>
       { :osfamily                  => 'Suse',
-        :lsbmajdistrelease         => '11',
+        :operatingsystemmajrelease         => '11',
         :package_name              => 'nscd',
         :server_user               => nil,
         :service_provider          => nil,
@@ -64,7 +64,7 @@ describe 'nscd' do
       },
     'suse12' =>
       { :osfamily                  => 'Suse',
-        :lsbmajdistrelease         => '12',
+        :operatingsystemmajrelease         => '12',
         :package_name              => 'nscd',
         :server_user               => 'nscd',
         :service_provider          => 'systemd',
@@ -74,7 +74,7 @@ describe 'nscd' do
       },
     'suse13' =>
       { :osfamily                  => 'Suse',
-        :lsbmajdistrelease         => '13',
+        :operatingsystemmajrelease         => '13',
         :package_name              => 'nscd',
         :server_user               => 'nscd',
         :service_provider          => 'systemd',
@@ -84,7 +84,7 @@ describe 'nscd' do
       },
     'ubuntu12' =>
       { :osfamily                  => 'Debian',
-        :lsbmajdistrelease         => '12',
+        :operatingsystemmajrelease         => '12',
         :package_name              => 'nscd',
         :server_user               => nil,
         :service_provider          => nil,
@@ -95,9 +95,9 @@ describe 'nscd' do
   }
 
   platforms.sort.each do |k,v|
-    describe "on #{v[:osfamily]} #{v[:lsbmajdistrelease]} with default values for all parameters" do
+    describe "on #{v[:osfamily]} #{v[:operatingsystemmajrelease]} with default values for all parameters" do
       let(:facts) do
-        { :lsbmajdistrelease => v[:lsbmajdistrelease],
+        { :operatingsystemmajrelease => v[:operatingsystemmajrelease],
           :osfamily          => v[:osfamily],
         }
       end
@@ -244,13 +244,13 @@ describe 'nscd' do
     context 'versions of EL' do
       let :facts do
         { :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '4',
+          :operatingsystemmajrelease => '4',
         }
 
         it 'should fail' do
           expect {
             should contain_class('nscd')
-          }.to raise_error(Puppet::Error,/Nscd is only supported on EL 5 and 6. Your lsbmajdistrelease is identified as <4>\./)
+          }.to raise_error(Puppet::Error,/Nscd is only supported on EL 5 and 6. Your operatingsystemmajrelease is identified as <4>\./)
         end
       end
     end
@@ -258,13 +258,13 @@ describe 'nscd' do
     context 'versions of Suse' do
       let :facts do
         { :osfamily          => 'Suse',
-          :lsbmajdistrelease => '4',
+          :operatingsystemmajrelease => '4',
         }
 
         it 'should fail' do
           expect {
             should contain_class('nscd')
-          }.to raise_error(Puppet::Error,/Nscd is only supported on Suse 10, 11, 12 and 13. Your lsbmajdistrelease is identified as <4>\./)
+          }.to raise_error(Puppet::Error,/Nscd is only supported on Suse 10, 11, 12 and 13. Your operatingsystemmajrelease is identified as <4>\./)
         end
       end
     end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -4,7 +4,7 @@ describe 'nscd' do
   platforms = {
     'debian6' =>
       { :osfamily                  => 'Debian',
-        :operatingsystemmajrelease         => '6',
+        :operatingsystemmajrelease => '6',
         :package_name              => 'nscd',
         :server_user               => nil,
         :service_provider          => nil,
@@ -14,7 +14,7 @@ describe 'nscd' do
       },
     'el5' =>
       { :osfamily                  => 'RedHat',
-        :operatingsystemmajrelease         => '5',
+        :operatingsystemmajrelease => '5',
         :package_name              => 'nscd',
         :server_user               => 'nscd',
         :service_provider          => nil,
@@ -24,7 +24,7 @@ describe 'nscd' do
       },
     'el6' =>
       { :osfamily                  => 'RedHat',
-        :operatingsystemmajrelease         => '6',
+        :operatingsystemmajrelease => '6',
         :package_name              => 'nscd',
         :server_user               => 'nscd',
         :service_provider          => nil,
@@ -34,7 +34,7 @@ describe 'nscd' do
       },
     'el7' =>
       { :osfamily                  => 'RedHat',
-        :operatingsystemmajrelease         => '7',
+        :operatingsystemmajrelease => '7',
         :package_name              => 'nscd',
         :server_user               => 'nscd',
         :service_provider          => nil,
@@ -44,7 +44,7 @@ describe 'nscd' do
       },
     'suse10' =>
       { :osfamily                  => 'Suse',
-        :operatingsystemmajrelease         => '10',
+        :operatingsystemmajrelease => '10',
         :package_name              => 'nscd',
         :server_user               => nil,
         :service_provider          => nil,
@@ -54,7 +54,7 @@ describe 'nscd' do
       },
     'suse11' =>
       { :osfamily                  => 'Suse',
-        :operatingsystemmajrelease         => '11',
+        :operatingsystemmajrelease => '11',
         :package_name              => 'nscd',
         :server_user               => nil,
         :service_provider          => nil,
@@ -64,7 +64,7 @@ describe 'nscd' do
       },
     'suse12' =>
       { :osfamily                  => 'Suse',
-        :operatingsystemmajrelease         => '12',
+        :operatingsystemmajrelease => '12',
         :package_name              => 'nscd',
         :server_user               => 'nscd',
         :service_provider          => 'systemd',
@@ -74,7 +74,7 @@ describe 'nscd' do
       },
     'suse13' =>
       { :osfamily                  => 'Suse',
-        :operatingsystemmajrelease         => '13',
+        :operatingsystemmajrelease => '13',
         :package_name              => 'nscd',
         :server_user               => 'nscd',
         :service_provider          => 'systemd',
@@ -84,7 +84,7 @@ describe 'nscd' do
       },
     'ubuntu12' =>
       { :osfamily                  => 'Debian',
-        :operatingsystemmajrelease         => '12',
+        :operatingsystemmajrelease => '12',
         :package_name              => 'nscd',
         :server_user               => nil,
         :service_provider          => nil,
@@ -243,7 +243,7 @@ describe 'nscd' do
 
     context 'versions of EL' do
       let :facts do
-        { :osfamily          => 'RedHat',
+        { :osfamily                  => 'RedHat',
           :operatingsystemmajrelease => '4',
         }
 
@@ -257,7 +257,7 @@ describe 'nscd' do
 
     context 'versions of Suse' do
       let :facts do
-        { :osfamily          => 'Suse',
+        { :osfamily                  => 'Suse',
           :operatingsystemmajrelease => '4',
         }
 


### PR DESCRIPTION
Hi,

I'd like to change the fact that currently determines the major release of a distribution from `lsbmajdistrelease` to `operatingsystemmajrelease`. This is due to the reason that `operatingsystemmajrelease` is supported nativley by all the distros without additional packages. To have the fact `lsbmajdistrelease` available on an RedHat flavoured OS like centos, scientificlinux ... the installation of an additional package `redhat-lsb-core` is required.

Is there any reason for preferring `lsbmajdistrelease` ?

Thanks in advance for checking my PR,
mat1010