### PR TITLE
Bump stdlib dependency < 7.0.0 to comply with the latest version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache: bundler
 
 before_install:
   - if [ $BUNDLER_VERSION ]; then
-      gem install -v $BUNDLER_VERSION bundler --no-rdoc --no-ri;
+      gem install -v $BUNDLER_VERSION bundler --no-document;
     fi
   - bundle -v
   - rm Gemfile.lock || true

--- a/metadata.json
+++ b/metadata.json
@@ -98,6 +98,6 @@
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 6.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 7.0.0"}
   ]
 }


### PR DESCRIPTION
Due to the latest releases of the puppetlabs/stdlib module we have to bump the dependency. I'm unning this module since several months with stdlib > 6.0.0 without issues. @ghoneycutt would be great if you could have a look at it.